### PR TITLE
[Chore] Fix nixfmt arguments

### DIFF
--- a/js/JSInterface.hs
+++ b/js/JSInterface.hs
@@ -10,6 +10,7 @@ import GHC.JS.Prim
 import Data.Text as T
 
 import Nixfmt
+import Nixfmt.Predoc (layout)
 
 foreign import javascript "((f) => { nixfmt_ = f })"
   setNixfmt :: Callback (JSVal -> JSVal -> IO JSVal) -> IO ()
@@ -19,6 +20,6 @@ main = setNixfmt =<< syncCallback2' \text_ obj -> do
   width <- fromJSInt <$> getProp obj "width"
   filename <- fromJSString <$> getProp obj "filename"
   let text = T.pack $ fromJSString text_
-  pure $ toJSString case format width filename text of
+  pure $ toJSString case format (layout width False) filename text of
     Left err -> err
     Right out -> T.unpack out


### PR DESCRIPTION
Problem: The `format` function parameters have changed, we need to change the arguments accordingly.

Solution: Pass `layout` with format width and boolean value to control whether the format should be strict (independent of user input) as the first argument.