### PR TITLE
[Chore] Compress JS code using 'closure-compiler'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
       - name: build nixfmt-js
         run: nix build .#nixfmt-js
 
+      - name: build webdemo
+        run: nix build .#nixfmt-webdemo
+
   deploy:
     runs-on: [self-hosted, nix]
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,9 @@
           mkdir $out
           cp ${./js/index.html} $out/index.html
           cp ${./js/404.html} $out/404.html
-          cp ${self.packages.${system}.nixfmt-js}/bin/js-interface $out/nixfmt.js
+          ${pkgs.closurecompiler}/bin/closure-compiler --assume_function_wrapper \
+            --js ${self.packages.${system}.nixfmt-js}/bin/js-interface \
+            --js_output_file $out/nixfmt.js
         '';
         inherit (pkgs) awscli;
       };


### PR DESCRIPTION
Problem: nixmft JS "binary" is somewhat large (~11M).

Solution: Compress it using 'closure-compiler' for 'nixfmt-webdemo'.
The resulting 'nixfmt.js' is now ~5M.

Perhaps, we can achieve even better compression rate once https://gitlab.haskell.org/ghc/ghc/-/issues/24584 is resolved.